### PR TITLE
Clerk login and customer lookup error messages and other UX details

### DIFF
--- a/screens/ClerkLoginScreen.js
+++ b/screens/ClerkLoginScreen.js
@@ -98,11 +98,8 @@ export default class ClerkLoginScreen extends React.Component {
               </Title>
               <Title color="#fff">Enter your employee PIN</Title>
               <TextField
-                style={
-                  this.state.errorShown
-                    ? { marginTop: 32, borderWidth: 2, borderColor: Colors.error }
-                    : { marginTop: 32, borderWidth: 2 }
-                }
+                style={{ marginTop: 32 }}
+                error={this.state.errorShown}
                 selectionColor={Colors.primaryGreen}
                 placeholder="ex. 1234"
                 keyboardType="number-pad"

--- a/screens/ClerkLoginScreen.js
+++ b/screens/ClerkLoginScreen.js
@@ -99,6 +99,7 @@ export default class ClerkLoginScreen extends React.Component {
               <Title color="#fff">Enter your employee PIN</Title>
               <TextField
                 autoFocus
+                clearButtonMode={'always'}
                 style={{ marginTop: 32 }}
                 error={this.state.errorShown}
                 selectionColor={Colors.primaryGreen}

--- a/screens/ClerkLoginScreen.js
+++ b/screens/ClerkLoginScreen.js
@@ -53,10 +53,10 @@ export default class ClerkLoginScreen extends React.Component {
       const lookupResult = await lookupClerk(this.props.navigation.state.params.store.id, this.state.password);
 
       let clerkRecord = null;
-      let foundError = true;
+      let clerkNotFound = true;
       switch (lookupResult.status) {
         case status.MATCH:
-          foundError = false;
+          clerkNotFound = false;
           clerkRecord = lookupResult.record;
           await this._asyncLoginClerk(clerkRecord);
           this.props.navigation.navigate('CustomerLookup');
@@ -74,7 +74,7 @@ export default class ClerkLoginScreen extends React.Component {
         default:
           return;
       }
-      this.setState({ errorMsg: lookupResult.errorMsg, password: '', errorShown: foundError });
+      this.setState({ errorMsg: lookupResult.errorMsg, password: '', errorShown: clerkNotFound });
     } catch (err) {
       console.error('Clerk Login Screen:', err);
     }

--- a/screens/ClerkLoginScreen.js
+++ b/screens/ClerkLoginScreen.js
@@ -98,6 +98,7 @@ export default class ClerkLoginScreen extends React.Component {
               </Title>
               <Title color="#fff">Enter your employee PIN</Title>
               <TextField
+                autoFocus
                 style={{ marginTop: 32 }}
                 error={this.state.errorShown}
                 selectionColor={Colors.primaryGreen}

--- a/screens/CustomerLookupScreen.js
+++ b/screens/CustomerLookupScreen.js
@@ -60,10 +60,10 @@ export default class CustomerLookupScreen extends React.Component {
       const lookupResult = await lookupCustomer(formattedPhoneNumber);
       let customerRecord = null;
 
-      let foundError = true;
+      let customerNotFound = true;
       switch (lookupResult.status) {
         case status.FOUND:
-          foundError = false;
+          customerNotFound = false;
           customerRecord = lookupResult.record;
           this._asyncCustomerFound(customerRecord);
           break;
@@ -77,7 +77,7 @@ export default class CustomerLookupScreen extends React.Component {
         default:
           return;
       }
-      this.setState({ errorMsg: lookupResult.errorMsg, phoneNumber: '', errorShown: foundError });
+      this.setState({ errorMsg: lookupResult.errorMsg, phoneNumber: '', errorShown: customerNotFound });
     } catch (err) {
       console.error('Customer Lookup Screen: ', err);
     }

--- a/screens/CustomerLookupScreen.js
+++ b/screens/CustomerLookupScreen.js
@@ -1,9 +1,10 @@
+import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { AsyncStorage, View } from 'react-native';
 import Colors from '../assets/Colors';
 import BackButton from '../components/BackButton';
-import { ButtonLabel, RoundedButtonContainer, Title } from '../components/BaseComponents';
+import { ButtonLabel, RoundedButtonContainer, Subhead, Title } from '../components/BaseComponents';
 import { status } from '../lib/constants';
 import { lookupCustomer } from '../lib/lookupUtils';
 import { CheckInContainer, CheckInContentContainer, TextField } from '../styled/checkin';
@@ -17,6 +18,7 @@ export default class CustomerLookupScreen extends React.Component {
       clerkName: '',
       phoneNumber: '',
       errorMsg: '',
+      errorShown: false,
       customerPermission: false
     };
   }
@@ -41,10 +43,14 @@ export default class CustomerLookupScreen extends React.Component {
 
   customerPermissionHandler = phoneNumber => {
     let customerPermission = false;
+    let errorShown = true;
+    if (phoneNumber.length > 0) {
+      errorShown = false;
+    }
     if (phoneNumber.length === 10) {
       customerPermission = true;
     }
-    this.setState({ phoneNumber, customerPermission });
+    this.setState({ phoneNumber, customerPermission, errorShown });
   };
 
   handleSubmit = async () => {
@@ -54,8 +60,10 @@ export default class CustomerLookupScreen extends React.Component {
       const lookupResult = await lookupCustomer(formattedPhoneNumber);
       let customerRecord = null;
 
+      let foundError = true;
       switch (lookupResult.status) {
         case status.FOUND:
+          foundError = false;
           customerRecord = lookupResult.record;
           this._asyncCustomerFound(customerRecord);
           break;
@@ -69,7 +77,7 @@ export default class CustomerLookupScreen extends React.Component {
         default:
           return;
       }
-      this.setState({ errorMsg: lookupResult.errorMsg, phoneNumber: '' });
+      this.setState({ errorMsg: lookupResult.errorMsg, phoneNumber: '', errorShown: foundError });
     } catch (err) {
       console.error('Customer Lookup Screen: ', err);
     }
@@ -97,13 +105,24 @@ export default class CustomerLookupScreen extends React.Component {
           <CheckInContentContainer>
             <Title>Enter customer phone number</Title>
             <TextField
-              style={{ marginTop: 32 }}
-              placeholder="(123) 456-7890"
+              style={
+                this.state.errorShown
+                  ? { marginTop: 32, borderWidth: 2, borderColor: Colors.error }
+                  : { marginTop: 32, borderWidth: 2 }
+              }
+              selectionColor={Colors.primaryGreen}
+              placeholder="ex. 1234567890"
               keyboardType="number-pad"
               maxLength={10}
               onChangeText={text => this.customerPermissionHandler(text)}
               value={this.state.phoneNumber}
             />
+            {this.state.errorShown && (
+              <RowContainer style={{ alignItems: 'center', marginTop: 8 }}>
+                <FontAwesome5 name="exclamation-circle" size={16} color={Colors.error} style={{ marginRight: 8 }} />
+                <Subhead color={Colors.activeText}>Invalid phone number</Subhead>
+              </RowContainer>
+            )}
             <RoundedButtonContainer
               style={{ marginTop: 32 }}
               color={this.state.customerPermission ? Colors.primaryGreen : Colors.lightestGreen}

--- a/screens/CustomerLookupScreen.js
+++ b/screens/CustomerLookupScreen.js
@@ -105,6 +105,8 @@ export default class CustomerLookupScreen extends React.Component {
           <CheckInContentContainer>
             <Title>Enter customer phone number</Title>
             <TextField
+              clearButtonMode={'always'}
+              selectionColor={Colors.primaryGreen}
               style={{ marginTop: 32 }}
               error={this.state.errorShown}
               placeholder="ex. 1234567890"

--- a/screens/CustomerLookupScreen.js
+++ b/screens/CustomerLookupScreen.js
@@ -105,12 +105,8 @@ export default class CustomerLookupScreen extends React.Component {
           <CheckInContentContainer>
             <Title>Enter customer phone number</Title>
             <TextField
-              style={
-                this.state.errorShown
-                  ? { marginTop: 32, borderWidth: 2, borderColor: Colors.error }
-                  : { marginTop: 32, borderWidth: 2 }
-              }
-              selectionColor={Colors.primaryGreen}
+              style={{ marginTop: 32 }}
+              error={this.state.errorShown}
               placeholder="ex. 1234567890"
               keyboardType="number-pad"
               maxLength={10}

--- a/screens/StoreLookupScreen.js
+++ b/screens/StoreLookupScreen.js
@@ -99,11 +99,13 @@ export default class StoreLookupScreen extends React.Component {
           <CheckInContentContainer>
             <Title color={Colors.lightest}>Enter store name</Title>
             <TextField
+              selectionColor={Colors.primaryGreen}
               style={{ marginTop: 32 }}
               placeholder="ex: Healthy Corner Store"
               onChangeText={text => this.handleChangeText(text)}
               value={this.state.searchStr}
               onFocus={() => this.onFocus()}
+              autoCorrect={false}
             />
             {!this.state.textFieldBlur && (
               <SearchBarContainer>
@@ -120,7 +122,7 @@ export default class StoreLookupScreen extends React.Component {
               <RoundedButtonContainer
                 style={{ marginTop: 32 }}
                 color={this.state.storePermission ? Colors.primaryGreen : Colors.lightestGreen}
-                width="253px"
+                width="100%"
                 height="40px"
                 onPress={() => this.handleNavigate()}
                 disabled={!this.state.storePermission}>

--- a/screens/StoreLookupScreen.js
+++ b/screens/StoreLookupScreen.js
@@ -100,6 +100,7 @@ export default class StoreLookupScreen extends React.Component {
           <CheckInContentContainer>
             <Title color={Colors.lightest}>Enter store name</Title>
             <TextField
+              clearButtonMode={'always'}
               selectionColor={Colors.primaryGreen}
               style={{ marginTop: 32 }}
               placeholder="ex: Healthy Corner Store"
@@ -110,7 +111,7 @@ export default class StoreLookupScreen extends React.Component {
             />
             {!this.state.textFieldBlur && (
               <SearchBarContainer>
-                <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
+                <ScrollView bounces={false} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
                   {this.state.filteredStores.map(store => (
                     <SearchElement key={store.id} onPress={() => this.onSearchElementPress(store)}>
                       <Body>{store.storeName}</Body>

--- a/screens/StoreLookupScreen.js
+++ b/screens/StoreLookupScreen.js
@@ -80,6 +80,7 @@ export default class StoreLookupScreen extends React.Component {
     this.setState({ searchStr: store.storeName, store, textFieldBlur: true });
     this.storePermissionHandler(store);
     this.updateFilteredStores(store.storeName);
+    Keyboard.dismiss();
   };
 
   handleNavigate = () => {
@@ -109,7 +110,7 @@ export default class StoreLookupScreen extends React.Component {
             />
             {!this.state.textFieldBlur && (
               <SearchBarContainer>
-                <ScrollView showsVerticalScrollIndicator={false}>
+                <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
                   {this.state.filteredStores.map(store => (
                     <SearchElement key={store.id} onPress={() => this.onSearchElementPress(store)}>
                       <Body>{store.storeName}</Body>

--- a/screens/modals/QuantityModal.js
+++ b/screens/modals/QuantityModal.js
@@ -119,7 +119,12 @@ export default class QuantityModal extends React.Component {
                   <Body>OR press the top left X to exit.</Body>
                 </ColumnContainer>
               </ModalCopyContainer>
-              <QuantityInput placeholder="Quantity" onChangeText={this.updateQuantity} value={currentQuantity} />
+              <QuantityInput
+                autoFocus
+                placeholder="Quantity"
+                onChangeText={this.updateQuantity}
+                value={currentQuantity}
+              />
               <RoundedButtonContainer
                 color={currentQuantity === '' ? Colors.lightestGreen : Colors.primaryGreen}
                 disabled={currentQuantity === ''}

--- a/styled/checkin.js
+++ b/styled/checkin.js
@@ -26,8 +26,8 @@ export const TextField = styled.TextInput`
   width: 253px;
   height: 51px;
   background-color: #fff;
-  border-color: ${Colors.base};
-  border-width: 1px;
+  border-color: ${props => (props.error ? Colors.error : Colors.base)};
+  border-width: 2px;
   padding-left: 14px;
   font-family: poppins-regular;
 `;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
* Added error messages and text field styling to match the Figma for invalid clerk PINs and invalid customer phone numbers.
* Various usability details originally noted on #16 and #14 including:
  * Automatically setting focus on text fields on Qty modal and clerk PIN
  * Fixing issue where you had to tap twice to dismiss the keyboard then select from the list

## Relevant Links

### Online sources

[//]: # "Optional - copy links to any tutorial or documentation that was useful to you when working on this PR"
KeyboardShouldPersistTaps: https://github.com/GeekyAnts/NativeBase/issues/1117

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
Cleaning up remaining details from #14 and #16 

## How to review
[//]: # "The order in which to review files and what to expect when testing locally"
* Go through the login/lookup flow a couple of times and see if it feels smooth to use. 
* I felt kind of iffy on my `foundError = true` method of getting around the switch looking at different lookup results in both `ClerkLoginScreen.js` and `CustomerLookupScreen.js` so I'd appreciate some more opinions.
* Same with the way I handled the textField border color and error message popup

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"
* I could not figure out how to fix the tapping twice to dismiss keyboard issue on the quantity modal. This article mentioned the same issue clashing with react native Modals and their solution was to trace it to a ScrollView, but even when I tried adding `KeyboardShouldPersistTaps="handled"` in the `ScrollView` containing `QuantityModal` on `CheckoutScreen.js`, it didn't work. Help would be appreciated :^)
https://medium.com/react-native-training/how-to-dismiss-keyboard-with-react-navigation-in-react-native-apps-4b987bbfdc48

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"
* Tested with various bad passwords/phone numbers to trigger the errors

### Screenshots
Here's the full behavior:
https://www.loom.com/share/c140de1495524058a57b2ec998443245

* Clerk login error state
![image](https://user-images.githubusercontent.com/21160510/77384610-0b6ab380-6d43-11ea-921d-053cd3b3f9bb.png)

* Error message clears once you start typing agan
![image](https://user-images.githubusercontent.com/21160510/77384623-132a5800-6d43-11ea-86dc-1794b5179a61.png)

* Customer lookup error state
![image](https://user-images.githubusercontent.com/21160510/77384639-20dfdd80-6d43-11ea-96f1-112cc1f4780e.png)

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98 @tommypoa 

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
