### PR TITLE
'Eligible rewards not applied' alert

### DIFF
--- a/lib/checkoutUtils.js
+++ b/lib/checkoutUtils.js
@@ -6,7 +6,7 @@ import {
   updateCustomers,
   updateTransactions
 } from './airtable/request';
-import { rewardPointValue } from './constants';
+import { rewardDollarValue, rewardPointValue } from './constants';
 
 // Adds a field 'imageUrl' to products
 function createProductData(record) {
@@ -69,6 +69,17 @@ export async function addTransaction(customer, cart, transactionInfo) {
   await updateTransactions(transactionId, { productsPurchasedId: itemIds });
 
   return transactionId;
+}
+
+// Calculate eligible rewards
+/* If negative balance exists, no additional rewards allowed!
+  Must take into account the current rewards applied
+  */
+export function calculateEligibleRewards(rewardsAvailable, rewardsApplied, totalBalance) {
+  const additionalRewardsAllowed = totalBalance > 0 ? Math.ceil(totalBalance / rewardDollarValue) : 0;
+  const additionalRewardsAvailable = rewardsAvailable - rewardsApplied;
+  const additionalRewardsEligible = Math.min(additionalRewardsAllowed, additionalRewardsAvailable);
+  return rewardsApplied + additionalRewardsEligible;
 }
 
 export function calculateLineItemPrice(product) {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-addons-update": "^15.6.2",
     "react-dom": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native-alert-async": "^1.0.5",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-screens": "^1.0.0-alpha.23",
     "react-native-web": "^0.11.7",

--- a/screens/CheckoutScreen.js
+++ b/screens/CheckoutScreen.js
@@ -152,9 +152,8 @@ export default class CheckoutScreen extends React.Component {
         this.state.rewardsApplied,
         this.state.totalBalance
       );
-      const eligibleSavings = eligibleRewards * rewardDollarValue;
-      if (eligibleRewards) {
-        const continueWithoutRewards = await this.confirmNoRewards(eligibleSavings, eligibleRewards);
+      if (eligibleRewards && transactionInfo.totalSale >= rewardDollarValue) {
+        const continueWithoutRewards = await this.confirmNoRewards(eligibleRewards);
         if (!continueWithoutRewards) {
           return;
         }
@@ -169,7 +168,7 @@ export default class CheckoutScreen extends React.Component {
     ]);
   };
 
-  confirmNoRewards = async (eligibleSavings, eligibleRewards) => {
+  confirmNoRewards = async eligibleRewards => {
     const response = await AlertAsync(
       'Available rewards were not applied',
       'This customer could apply up to '.concat(eligibleRewards).concat(' rewards to this sale.'),

--- a/screens/CheckoutScreen.js
+++ b/screens/CheckoutScreen.js
@@ -172,10 +172,7 @@ export default class CheckoutScreen extends React.Component {
   confirmNoRewards = async (eligibleSavings, eligibleRewards) => {
     const response = await AlertAsync(
       'Available rewards were not applied',
-      'This customer could apply up to '
-        .concat(eligibleRewards)
-        .concat(' rewards to this sale and save up to ')
-        .concat(displayDollarValue(eligibleSavings)),
+      'This customer could apply up to '.concat(eligibleRewards).concat(' rewards to this sale.'),
       [
         {
           text: 'Go back to apply rewards',

--- a/screens/modals/RewardModal.js
+++ b/screens/modals/RewardModal.js
@@ -12,7 +12,7 @@ import {
   SquareButtonContainer,
   Title
 } from '../../components/BaseComponents';
-import { displayDollarValue } from '../../lib/checkoutUtils';
+import { calculateEligibleRewards, displayDollarValue } from '../../lib/checkoutUtils';
 import { rewardDollarValue } from '../../lib/constants';
 import {
   ModalCenteredOpacityLayer,
@@ -55,18 +55,11 @@ export default class RewardModal extends React.Component {
   }
 
   _updateState = (rewardsAvailable, rewardsApplied, totalBalance) => {
-    // Calculate eligible rewards
-    /* If negative balance exists, no additional rewards allowed!
-      Must take into account the current rewards applied
-     */
-    const additionalRewardsAllowed = totalBalance > 0 ? Math.ceil(totalBalance / rewardDollarValue) : 0;
-    const additionalRewardsAvailable = rewardsAvailable - rewardsApplied;
-    const additionalRewardsEligible = Math.min(additionalRewardsAllowed, additionalRewardsAvailable);
     this.setState({
       rewardsAvailable,
       rewardsApplied,
       totalBalance,
-      rewardsEligible: rewardsApplied + additionalRewardsEligible
+      rewardsEligible: calculateEligibleRewards(rewardsAvailable, rewardsApplied, totalBalance)
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7181,6 +7181,11 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
+react-native-alert-async@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-native-alert-async/-/react-native-alert-async-1.0.5.tgz#f67e3d1f6c877cce8e8cd74cef3d596713f0fdb4"
+  integrity sha512-HeG0zdjtlANl8KkF9AhqgkaEooXip44Fb01dmCnYSYMm6PoRdcV4aIy6l/yAOQmArrl8LTP58APSiuZXBMCbwQ==
+
 react-native-branch@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-3.0.1.tgz#5b07b61cbd290168cd3c3662e017ebe0f356d2ca"


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
If the customer has rewards available but has not applied any, AND the cart total is greater than the reward dollar value, the clerk will be prompted to confirm that they want to complete the sale without applying rewards or go back to apply rewards.

For context, this was a feature that was included in some early versions of the designs but got phased out. The NPO used the version with this built-in for clerk user testing and thought it would be really important to add, especially since our rewards pilot is operating under the assumption that customers are able to participate in the program without the customer app. This way, even when customers might not remember to or be able to check if they have rewards available to apply, the clerks can remind them.

## Relevant Links

### Online sources

[//]: # "Optional - copy links to any tutorial or documentation that was useful to you when working on this PR"

### Related PRs


## How to review
* Please critique my code organization and variable naming!
* Try completing sales with different cart totals and reward amounts.


## Next steps
* If this 2-system-alerts-in-a-row flow receives negative feedback, consider building this out into a full modal like the original designs.

## Tests Performed, Edge Cases
* Tested with several combinations of rewards available and cart totals

### Screenshots
![image](https://user-images.githubusercontent.com/21160510/77717189-0b65f000-6f9d-11ea-8d59-cdd2b92a28fe.png)

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98 @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
