### PR TITLE
Truncate product card text overflow

### DIFF
--- a/components/ProductDisplayCard.js
+++ b/components/ProductDisplayCard.js
@@ -25,8 +25,12 @@ function ProductDisplayCard({ product }) {
         }}
         borderRadius={4}
       />
-      <Body>{product.name}</Body>
-      <Caption color={Colors.secondaryText}>{product.detail}</Caption>
+      <Body numberOfLines={1} ellipsizeMode="tail">
+        {product.name}
+      </Body>
+      <Caption numberOfLines={1} ellipsizeMode="tail" color={Colors.secondaryText}>
+        {product.detail}
+      </Caption>
     </ProductCard>
   );
 }


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
* Fixed #43 where some product titles and details overflowed the product cards.

## Relevant Links
### Online sources
https://reactnative.dev/docs/text#ellipsizemode

### Related PRs
Addressed the same issue in the customer app
https://github.com/calblueprint/dccentralkitchen/issues/125
https://github.com/calblueprint/dccentralkitchen/pull/127

## How to review
* Look at cards with longer store names and make sure the text does not overflow the card
  * Long detail line: Kale Mix (Fresh Express) 
  * Long title: Tangerines & Clementines

## Next steps
n/a

## Tests Performed, Edge Cases
n/a

### Screenshots
![image](https://user-images.githubusercontent.com/21160510/80891182-4ed80c00-8c77-11ea-85c8-b9f9714b0b3d.png)
![image](https://user-images.githubusercontent.com/21160510/80891184-53042980-8c77-11ea-917a-dbda8e2e4ca0.png)


CC: @anniero98

[//]: # 'This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
