### PR TITLE
Misc clerk fixes

### DIFF
--- a/components/LineItemCard.js
+++ b/components/LineItemCard.js
@@ -29,11 +29,20 @@ function LineItemCard({ product }) {
 
 LineItemCard.propTypes = {
   product: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    detail: PropTypes.string.isRequired,
-    points: PropTypes.number.isRequired,
-    quantity: PropTypes.number.isRequired,
-  }).isRequired,
+    name: PropTypes.string,
+    detail: PropTypes.string,
+    points: PropTypes.number,
+    quantity: PropTypes.number,
+  }),
+};
+
+LineItemCard.defaultProps = {
+  product: {
+    name: '',
+    detail: '',
+    points: 0,
+    quantity: 0,
+  },
 };
 
 export default LineItemCard;

--- a/components/ProductDisplayCard.js
+++ b/components/ProductDisplayCard.js
@@ -37,10 +37,18 @@ function ProductDisplayCard({ product }) {
 
 ProductDisplayCard.propTypes = {
   product: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    detail: PropTypes.string.isRequired,
-    imageUrl: PropTypes.string.isRequired,
-  }).isRequired,
+    name: PropTypes.string,
+    detail: PropTypes.string,
+    imageUrl: PropTypes.string,
+  }),
+};
+
+ProductDisplayCard.defaultProps = {
+  product: {
+    name: '',
+    detail: '',
+    imageUrl: '',
+  },
 };
 
 export default ProductDisplayCard;

--- a/screens/CheckoutScreen.js
+++ b/screens/CheckoutScreen.js
@@ -71,7 +71,7 @@ export default class CheckoutScreen extends React.Component {
       this.setState((prevState) => ({
         lineItems: prevState.lineItems.concat(product.id),
       }));
-    } else if (quantity === 0 && (product.id in this.state.lineItems)) {
+    } else if (quantity === 0 && (this.state.lineItems.includes(product.id))) {
       // Remove an item from lineItems.
       this.setState((prevState) => ({
         lineItems: prevState.lineItems.filter((id) => id !== product.id)

--- a/screens/CheckoutScreen.js
+++ b/screens/CheckoutScreen.js
@@ -67,13 +67,16 @@ export default class CheckoutScreen extends React.Component {
       3) The new balance is non-negative
       No special handling */
     // Add a new product to lineItems.
-    if (quantity !== 0 && !(product.id in this.state.lineItems)) {
-      this.setState((prevState) => ({lineItems: prevState.lineItems.push(product.id)}));
+    if (quantity !== 0 && !(this.state.lineItems.includes(product.id))) {
+      this.setState((prevState) => ({
+        lineItems: prevState.lineItems.concat(product.id),
+      }));
     } else if (quantity === 0 && (product.id in this.state.lineItems)) {
       // Remove an item from lineItems.
-      this.setState((prevState) => ({lineItems: prevState.lineItems.filter((id) => id !== product.id)}));
+      this.setState((prevState) => ({
+        lineItems: prevState.lineItems.filter((id) => id !== product.id)
+      }));
     }
-    console.log("lineitems", this.state.lineItems);
     if (priceDifference >= 0 || this.state.rewardsApplied === 0 || newBalance >= 0) {
       this.setState((prevState) => ({
         cart: update(prevState.cart, { [product.id]: { quantity: { $set: quantity } } }),

--- a/screens/CheckoutScreen.js
+++ b/screens/CheckoutScreen.js
@@ -66,11 +66,14 @@ export default class CheckoutScreen extends React.Component {
       2) No rewards have been applied, or
       3) The new balance is non-negative
       No special handling */
+    // Add a new product to lineItems.
     if (quantity !== 0 && !(product.id in this.state.lineItems)) {
-      this.state.lineItems.push(product.id);
+      this.setState((prevState) => ({lineItems: prevState.lineItems.push(product.id)}));
     } else if (quantity === 0 && (product.id in this.state.lineItems)) {
-      this.setState((prevState) => ({lineItems: prevState.lineItems.filter((item) => item !== product.id)}));
+      // Remove an item from lineItems.
+      this.setState((prevState) => ({lineItems: prevState.lineItems.filter((id) => id !== product.id)}));
     }
+    console.log("lineitems", this.state.lineItems);
     if (priceDifference >= 0 || this.state.rewardsApplied === 0 || newBalance >= 0) {
       this.setState((prevState) => ({
         cart: update(prevState.cart, { [product.id]: { quantity: { $set: quantity } } }),


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Changed `ProductDisplayCard` propTypes to be un-required (since it's possible for some products to not have a name, image, and/or detail line) and provided default props. This removes a warning on `CheckoutScreen`.
- Line items are no longer alphabetized -- now ordered by most recent in the cart.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links
Closes #56 
Closes #34 

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review
You shouldn't see the propTypes warning on the checkout screen anymore. Also, the "Current Sale" section should function as normal, but items most recently added should appear at the bottom of the list. Try adding and removing items.

[//]: # 'The order in which to review files and what to expect when testing locally'

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

[//]: # 'Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally'

### Screenshots
![IMG_2120](https://user-images.githubusercontent.com/21699109/81254478-035b9000-8fe0-11ea-9a8d-2484045ecc6b.PNG)

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98 @wangannie

[//]: # 'This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
