### PR TITLE
Release 1.2.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
     "updates": {
       "fallbackToCacheTimeout": 3000
     },
-    "assetBundlePatterns": ["**/*"],
+    "assetBundlePatterns": ["assets/images/*"],
     "ios": {
       "bundleIdentifier": "org.calblueprint.HealthyCornersClerk",
       "googleServicesFile": "./GoogleService-Info.plist",

--- a/app.json
+++ b/app.json
@@ -8,10 +8,10 @@
     "android": {
       "package": "org.calblueprint.HealthyCornersClerk",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 6,
+      "versionCode": 7,
       "permissions": []
     },
-    "version": "1.1.3",
+    "version": "1.2.0",
     "orientation": "landscape",
     "icon": "./assets/images/hc_clerk_icon.png",
     "splash": {
@@ -26,7 +26,7 @@
     "ios": {
       "bundleIdentifier": "org.calblueprint.HealthyCornersClerk",
       "googleServicesFile": "./GoogleService-Info.plist",
-      "buildNumber": "1.1.3",
+      "buildNumber": "1.2.0",
       "supportsTablet": true,
       "requireFullScreen": true
     },


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Bumped version numbers to 1.2.0
- Updated asset bundling patterns to only include images
